### PR TITLE
 Bugfix for bluescreen generated by AJAX

### DIFF
--- a/src/Tracy/BlueScreen/assets/content.phtml
+++ b/src/Tracy/BlueScreen/assets/content.phtml
@@ -23,6 +23,10 @@ namespace Tracy;
 
 $code = $exception->getCode() ? ' #' . $exception->getCode() : '';
 
+if (!isset($exceptions)) {
+	$exceptions = Helpers::getExceptionChain($exception);
+}
+
 ?>
 <div id="tracy-bs" itemscope>
 	<a id="tracy-bs-toggle" href="#" class="tracy-toggle"></a>


### PR DESCRIPTION
Bluescreen method render() requires content.phtml directly without page.phtml. This is causing undefined variable $exceptions for exceptions in AJAX calls. Bugfix appeared after fixing issue #499.